### PR TITLE
Add editors

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -17,7 +17,7 @@
         edDraftURI:           "https://w3c.github.io/sparql-service-description/spec/",
         testSuiteURI:         "https://w3c.github.io/rdf-tests/",
         shortName:            "sparql12-service-description",
-        copyrightStart:       "2008",
+        copyrightStart:       "2012",
          
         github:               "https://github.com/w3c/sparql-service-description",
         wgPublicList:         "public-rdf-star-wg",
@@ -32,7 +32,8 @@
         previousMaturity:     "REC",
         
          editors: [
-           { name: "RDF Star Working Group" }
+           { name: "Ruben Taelman", w3cid: "84199"},
+           { name: "Gregory Williams", w3cid: "38870"},
          ],
         formerEditors: [
           { name: "Gregory Todd Williams" },
@@ -44,7 +45,7 @@
       };
     </script>
 
-    <style type="text/css">
+    <style>
       @import url("local.css");
 
       /* ReSpec */
@@ -102,10 +103,7 @@
       </p>
     </section>
 
-    <!--
-        @@ Includes too much - all RDF documents.
-    <section id="related" data-include="./common/related.html"></section>
-    -->
+    <section id="related" data-include="common/sparql-related.html"></section>
 
     <section id="sparql12-documents" class="introductory">
       <h2>SPARQL 1.2 Documents</h2>


### PR DESCRIPTION
Also: aligns copyright date to SPARQL 1.1.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-service-description/pull/6.html" title="Last updated on Feb 10, 2023, 4:09 PM UTC (c048fe9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-service-description/6/98c9e73...c048fe9.html" title="Last updated on Feb 10, 2023, 4:09 PM UTC (c048fe9)">Diff</a>