### PR TITLE
Fix wrong link to SPARQL protocol, Closes #5

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -135,7 +135,7 @@
         <p>The following terms are also in use throughout this document:</p>
         <dl>
           <dt>SPARQL Service</dt>
-          <dd>Any implementation conforming to the <span class="doc-ref">SPARQL 1.1 Protocol for RDF</span> (this document's use of "SPARQL Service" is the same as "<a href=
+          <dd>Any implementation conforming to the [[[SPARQL12-PROTOCOL]]] (this document's use of "SPARQL Service" is the same as "<a href=
           "http://www.w3.org/TR/sparql11-protocol/#terminology">SPARQL Protocol service</a>" as defined in the SPARQL 1.1 Protocol) [<a href="#SPROT">SPROT</a>].</dd>
           <dt>SPARQL endpoint</dt>
           <dd>The URI at which a SPARQL Service listens for requests from clients.</dd>


### PR DESCRIPTION
All other href links to other specs should also still be updated, but let's leave that for another PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-service-description/pull/7.html" title="Last updated on Feb 17, 2023, 10:49 AM UTC (c0d95ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-service-description/7/30eda9e...c0d95ef.html" title="Last updated on Feb 17, 2023, 10:49 AM UTC (c0d95ef)">Diff</a>