### PR TITLE
Update RFC9110 reference

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -381,7 +381,7 @@ span.cancast:hover { background-color: #ffa;
       <h2>Accessing a Service Description</h2>
       <p>SPARQL services made available via the SPARQL Protocol <em class="rfc2119" title="Keyword in RFC 2119 context">SHOULD</em> return a service description document at the service endpoint when
       dereferenced using the HTTP GET operation without any query parameter strings provided. This service description <em class="rfc2119" title="Keyword in RFC 2119 context">MUST</em> be made
-      available in an RDF serialization, <em class="rfc2119" title="Keyword in RFC 2119 context">MAY</em> be embedded in (X)HTML by way of [[[RDFa-core]]], and <em class="rfc2119" title="Keyword in RFC 2119 context">SHOULD</em> use <a data-cite="rfc9110#section-12">content negotiation</a> if available in other RDF representations.</p>
+      available in an RDF serialization, <em class="rfc2119" title="Keyword in RFC 2119 context">MAY</em> be embedded in (X)HTML by way of [[[RDFa-core]]], and <em class="rfc2119" title="Keyword in RFC 2119 context">SHOULD</em> use <a data-cite="rfc9110#content.negotiation">content negotiation</a> if available in other RDF representations.</p>
     </section>
     <section id="vocab">
       <h2>Service Description Vocabulary</h2>


### PR DESCRIPTION
The RFC9110 reference now targets the `https://httpwg.org/specs/` version of the spec in ReSpec, and fragment identifiers need to be updated as a result.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/sparql-service-description/pull/23.html" title="Last updated on Nov 24, 2023, 2:58 PM UTC (9074854)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-service-description/23/bb35bff...tidoust:9074854.html" title="Last updated on Nov 24, 2023, 2:58 PM UTC (9074854)">Diff</a>