### PR TITLE
Add reference to new 1.2 languages in sd:Language text.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -783,8 +783,9 @@ span.cancast:hover { background-color: #ffa;
         <section id="sd-Language">
           <h4>sd:Language</h4>
           <p>An instance of <a href="#sd-Language"><code>sd:Language</code></a> represents one of the SPARQL languages, including specific configurations providing particular features or extensions.
-          This document defines three instances of <a href="#sd-Language"><code>sd:Language</code></a>: <a href="#lang-sparql10query"><code>sd:SPARQL10Query</code></a>, <a href=
-          "#lang-sparql11query"><code>sd:SPARQL11Query</code></a>, and <a href="#lang-sparql11update"><code>sd:SPARQL11Update</code></a>.</p>
+          This document defines five instances of <a href="#sd-Language"><code>sd:Language</code></a>: <a href="#lang-sparql10query"><code>sd:SPARQL10Query</code></a>, <a href=
+          "#lang-sparql11query"><code>sd:SPARQL11Query</code></a>, <a href="#lang-sparql11update"><code>sd:SPARQL11Update</code></a>, <a href=
+          "#lang-sparql12query"><code>sd:SPARQL12Query</code></a>, and <a href="#lang-sparql12update"><code>sd:SPARQL12Update</code></a>.</p>
           <table>
             <tbody>
               <tr>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-service-description/pull/38.html" title="Last updated on Mar 11, 2025, 4:16 PM UTC (ac561a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-service-description/38/806a148...ac561a6.html" title="Last updated on Mar 11, 2025, 4:16 PM UTC (ac561a6)">Diff</a>