### PR TITLE
Feature/version discovery

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1135,7 +1135,9 @@ Content-Type: application/rdf+xml
    xmlns:void="http://rdfs.org/ns/void#"&gt;
   &lt;sd:Service&gt;
     &lt;sd:endpoint rdf:resource="http://www.example/sparql/"/&gt;
-    &lt;sd:supportedLanguage rdf:resource="http://www.w3.org/ns/sparql-service-description#SPARQL11Query"/&gt;
+    &lt;sd:supportedLanguage rdf:resource="http://www.w3.org/ns/sparql-service-description#SPARQL12Query"/&gt;
+    &lt;sd:supportedVersion rdf:resource="http://www.w3.org/ns/sparql#version-1.2"/&gt;
+    &lt;sd:supportedVersion rdf:resource="http://www.w3.org/ns/sparql#version-1.2-basic"/&gt;
     &lt;sd:resultFormat rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
     &lt;sd:resultFormat rdf:resource="http://www.w3.org/ns/formats/Turtle"/&gt;
     &lt;sd:feature rdf:resource="http://www.w3.org/ns/sparql-service-description#DereferencesURIs"/&gt;
@@ -1186,10 +1188,12 @@ PREFIX sd: &lt;http://www.w3.org/ns/sparql-service-description#&gt;
 PREFIX ent: &lt;http://www.w3.org/ns/entailment/&gt;
 PREFIX prof: &lt;http://www.w3.org/ns/owl-profile/&gt;
 PREFIX void: &lt;http://rdfs.org/ns/void#&gt;
+PREFIX sparql: &lt;http://www.w3.org/ns/sparql#&gt;
 
 [] a sd:Service ;
     sd:endpoint &lt;http://www.example/sparql/&gt; ;
-    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:supportedLanguage sd:SPARQL12Query ;
+    sd:supportedVersion sparql:version-1.2, sparql:version-1.2-basic ;
     sd:resultFormat &lt;http://www.w3.org/ns/formats/RDF_XML&gt;, &lt;http://www.w3.org/ns/formats/Turtle&gt; ;
     sd:extensionFunction &lt;http://example.org/Distance&gt; ;
     sd:feature sd:DereferencesURIs ;


### PR DESCRIPTION
As a follow-up to https://github.com/w3c/sparql-query/pull/312, this PR adds the `sd:supportedVersion` predicate to the service description, to enable discovery of supported versions.

`sd:supportedVersion` could for example point to `sparql:version-1.2`.
Alternatively, we could also decide to just make `sd:supportedVersion` refer to strings (e.g. `1.2`).

Closes https://github.com/w3c/sparql-query/issues/241


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-service-description/pull/40.html" title="Last updated on Jan 12, 2026, 2:47 PM UTC (7e0f00a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-service-description/40/a54e441...7e0f00a.html" title="Last updated on Jan 12, 2026, 2:47 PM UTC (7e0f00a)">Diff</a>