### PR TITLE
Enable discovery of supported versions through new languages

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -970,6 +970,30 @@ span.cancast:hover { background-color: #ffa;
             </tbody>
           </table>
         </section>
+        <section id="lang-sparql11querywithversion">
+          <h4>sd:SPARQL11QueryWithVersion</h4>
+          <p><code>sd:SPARQL11QueryWithVersion</code> is an <a href="#sd-Language"><code>sd:Language</code></a> representing the [[[SPARQL11-QUERY]]], including the use of a version directive.</p>
+          <table>
+            <tbody>
+              <tr>
+                <th>type:</th>
+                <td><a href="#sd-Language"><code>sd:Language</code></a></td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+        <section id="lang-sparql11updatewithversion">
+          <h4>sd:SPARQL11UpdateWithVersion</h4>
+          <p><code>sd:SPARQL11UpdateWithVersion</code> is an <a href="#sd-Language"><code>sd:Language</code></a> representing the [[[SPARQL11-UPDATE]]] language, including the use of a version directive.</p>
+          <table>
+            <tbody>
+              <tr>
+                <th>type:</th>
+                <td><a href="#sd-Language"><code>sd:Language</code></a></td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
         <section id="lang-sparql12query">
           <h4>sd:SPARQL12Query</h4>
           <p><code>sd:SPARQL12Query</code> is an <a href="#sd-Language"><code>sd:Language</code></a> representing the [[[SPARQL12-QUERY]]].</p>
@@ -985,6 +1009,30 @@ span.cancast:hover { background-color: #ffa;
         <section id="lang-sparql12update">
           <h4>sd:SPARQL12Update</h4>
           <p><code>sd:SPARQL12Update</code> is an <a href="#sd-Language"><code>sd:Language</code></a> representing the [[[SPARQL12-UPDATE]]] language.</p>
+          <table>
+            <tbody>
+              <tr>
+                <th>type:</th>
+                <td><a href="#sd-Language"><code>sd:Language</code></a></td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+        <section id="lang-sparql12querybasic">
+          <h4>sd:SPARQL12QueryBasic</h4>
+          <p><code>sd:SPARQL12QueryBasic</code> is an <a href="#sd-Language"><code>sd:Language</code></a> representing the [[[SPARQL12-QUERY]]] without triple terms.</p>
+          <table>
+            <tbody>
+              <tr>
+                <th>type:</th>
+                <td><a href="#sd-Language"><code>sd:Language</code></a></td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+        <section id="lang-sparql12updatebasic">
+          <h4>sd:SPARQL12UpdateBasic</h4>
+          <p><code>sd:SPARQL12UpdateBasic</code> is an <a href="#sd-Language"><code>sd:Language</code></a> representing the [[[SPARQL12-UPDATE]]] language without triple terms.</p>
           <table>
             <tbody>
               <tr>


### PR DESCRIPTION
This is a variant of #40 based on the proposal of @kasei (please let me know if I misrepresented your view).
So we should only merge either #40 or this one (or none).

Closes w3c/sparql-query#241


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-service-description/pull/44.html" title="Last updated on Jan 26, 2026, 12:05 PM UTC (7126061)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-service-description/44/a54e441...7126061.html" title="Last updated on Jan 26, 2026, 12:05 PM UTC (7126061)">Diff</a>